### PR TITLE
Use str() on passwords set through the admin form

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -24,9 +24,10 @@ class Form(BaseForm):
     def to_settings(self, data, settings):
         is_stage = settings.get('DEBUG')
         if is_stage:
+            password = data.get('email_host_password_stage') or data.get('email_host_password')
             email_settings = {
                 'EMAIL_HOST': data.get('email_host_stage') or data.get('email_host'),
-                'EMAIL_HOST_PASSWORD': str(data.get('email_host_password_stage') or data.get('email_host_password')),
+                'EMAIL_HOST_PASSWORD': password.encode('ascii') if password else None,
                 'EMAIL_HOST_USER': data.get('email_host_user_stage') or data.get('email_host_user'),
                 'EMAIL_PORT': data.get('email_port_stage') or data.get('email_port'),
                 'EMAIL_USE_TLS': data.get('email_use_tls_stage') or data.get('email_use_tls'),
@@ -38,9 +39,10 @@ class Form(BaseForm):
                     'MANDRILL_API_KEY': stage_mandrill_api_key
                 })
         else:
+            password = data.get('email_host_password')
             email_settings = {
                 'EMAIL_HOST': data.get('email_host'),
-                'EMAIL_HOST_PASSWORD': str(data.get('email_host_password')),
+                'EMAIL_HOST_PASSWORD': password.encode('ascii') if password else None,
                 'EMAIL_HOST_USER': data.get('email_host_user'),
                 'EMAIL_PORT': data.get('email_port'),
                 'EMAIL_USE_TLS': data.get('email_use_tls'),

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -26,7 +26,7 @@ class Form(BaseForm):
         if is_stage:
             email_settings = {
                 'EMAIL_HOST': data.get('email_host_stage') or data.get('email_host'),
-                'EMAIL_HOST_PASSWORD': data.get('email_host_password_stage') or data.get('email_host_password'),
+                'EMAIL_HOST_PASSWORD': str(data.get('email_host_password_stage') or data.get('email_host_password')),
                 'EMAIL_HOST_USER': data.get('email_host_user_stage') or data.get('email_host_user'),
                 'EMAIL_PORT': data.get('email_port_stage') or data.get('email_port'),
                 'EMAIL_USE_TLS': data.get('email_use_tls_stage') or data.get('email_use_tls'),
@@ -40,7 +40,7 @@ class Form(BaseForm):
         else:
             email_settings = {
                 'EMAIL_HOST': data.get('email_host'),
-                'EMAIL_HOST_PASSWORD': data.get('email_host_password'),
+                'EMAIL_HOST_PASSWORD': str(data.get('email_host_password')),
                 'EMAIL_HOST_USER': data.get('email_host_user'),
                 'EMAIL_PORT': data.get('email_port'),
                 'EMAIL_USE_TLS': data.get('email_use_tls'),


### PR DESCRIPTION
The `to_settings()` method sets settings values as Unicode strings.
If Email server claims to support CRAM-MD5 auth smtplib uses it (as it is [the preferred method](https://github.com/python/cpython/blob/70aee71ad72216/Lib/smtplib.py#L593)).

The problem is that `hmac` module [operates on bytes, not text](http://bugs.python.org/issue5285). So, calling `str()` on password seems to be the possible workaround.